### PR TITLE
Use public ECR for image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.15-otp-25-alpine
+FROM public.ecr.aws/docker/library/elixir:1.15-otp-25-alpine 
 
 COPY . .
 


### PR DESCRIPTION
Dockerhub will heavily constrict its unauthorized pulls and to avert any possible issues from it we are migrating images to be pulled from ECR instead

DEVEXP-961